### PR TITLE
feat(controller): add support for authenticated external registry.

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -20,3 +20,4 @@ semantic_version==2.4.2
 simpleflock==0.0.2
 South==1.0.2
 static==1.1.1
+awscli

--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -70,3 +70,12 @@ GROUP_BASEDN = '{{ if exists "/deis/controller/auth/ldap/group/basedn" }}{{ getv
 GROUP_FILTER = '{{ if exists "/deis/controller/auth/ldap/group/filter" }}{{ getv "/deis/controller/auth/ldap/group/filter"}}{{ else }} {{ end }}'
 GROUP_TYPE = '{{ if exists "/deis/controller/auth/ldap/group/type" }}{{ getv "/deis/controller/auth/ldap/group/type"}}{{ else }} {{ end }}'
 {{ end }}
+
+#EXTERNAL REGISTRY AUTH
+PRIVATE_EXT_REGISTRY = False
+{{ if exists "/deis/controller/private_ext_registry/flavor" }}
+import json
+PRIVATE_EXT_REGISTRY = True
+PRIVATE_EXT_REGISTRY_FLAVOR = '{{ getv "/deis/controller/private_ext_registry/flavor" }}'
+PRIVATE_EXT_REGISTRY_DATA = json.loads('''{{ getv "/deis/controller/private_ext_registry/data" }}'''.replace("\'", '"'))
+{{ end }}


### PR DESCRIPTION
This patch add ability to use an private image (stored on private docker hub
or aws ECR or quay) as a base for deployment with deis pull command.
For now we can only setup one external registry at a time, the plan in the future
is to support multiple private registry at the same time.

Those etcd keys were added:
- /deis/controller/private_ext_registry/flavor:
  contains the type of the authentication, two value are
  accepted 'ecr' and 'default'.
  - when ecr is used, we assume we are
    running on aws ec2 and this the instance we are working on has an attahced
    role to issue aws ecr get-login,
    also in this case 'data' would be a json dict containing the region
    where the regitry is configured.
  - when 'default' is used, the data would contain a json dict
    with username, passowrd, registry, and email to use for docker login.
- /deis/controller/private_ext_registry/data
