### PR TITLE
FIXES/DOS-2452 stable controller

### DIFF
--- a/controller/bin/boot
+++ b/controller/bin/boot
@@ -122,8 +122,8 @@ if [[ ! -z $EXTERNAL_PORT ]]; then
 
 	# while the port is listening, publish to etcd
 	while [[ ! -z $(netstat -lnt | awk "\$6 == \"LISTEN\" && \$4 ~ \".$PORT\" && \$1 ~ \"$PROTO.?\"") ]] ; do
-		etcdctl --no-sync -C "$ETCD" set "$ETCD_PATH/host" "$HOST" --ttl "$ETCD_TTL" >/dev/null
-		etcdctl --no-sync -C "$ETCD" set "$ETCD_PATH/port" "$EXTERNAL_PORT" --ttl "$ETCD_TTL" >/dev/null
+		etcdctl -C "$ETCD" set "$ETCD_PATH/host" "$HOST" --ttl "$ETCD_TTL" >/dev/null
+		etcdctl -C "$ETCD" set "$ETCD_PATH/port" "$EXTERNAL_PORT" --ttl "$ETCD_TTL" >/dev/null
 		sleep $((ETCD_TTL/2)) # sleep for half the TTL
 	done
 


### PR DESCRIPTION
Because it can happen that under load of confd the refresh of the
controller IP in etcd takes more time then the ttl.
Leading to a situation where the controller is not accessible
from the router (router returning 503).

By removing the --no-sync value, we ensure that the etcd value
would be sent after member synchronisation, which means we would
ask for memeber IPs and route the request directly to etcd main
member, to garantee the value is written correctly.
