### PR TITLE
Improve the availability zone distribution logic.

### DIFF
--- a/controller/templates/confd_settings.py
+++ b/controller/templates/confd_settings.py
@@ -80,8 +80,3 @@ PRIVATE_EXT_REGISTRY_FLAVOR = '{{ getv "/deis/controller/private_ext_registry/fl
 PRIVATE_EXT_REGISTRY_DATA = json.loads('''{{ getv "/deis/controller/private_ext_registry/data" }}'''.replace("\'", '"'))
 {{ end }}
 
-# if defined, then scheduler will distribute the units cross that list.
-# it is a list of anything, the scheduler would pick az = AVAILABILITY_ZONE_LIST[num % len(AVAILABILITY_ZONE_LIST)]
-# which means if list is ['a', 'b'], and it is the 3rd container of the same application,
-# we would do, 3 % 2 = 1 => az = list(1) => az=b
-AVAILABILITY_ZONE_LIST={{ if exists "/deis/controller/AZs" }}json.loads('''{{ getv "/deis/controller/AZs" }}'''.replace("\'", '"')){{ else }}[]{{ end }}


### PR DESCRIPTION
Improve the availability zone distribution logic.
We don't rely on a static list of "available" availability zone name anymore.
The list is dynamicly created from fleet metadata.
The tags used is always named "az" (might be improved by making the
tag name a parameter).

So if the machines are tagged with az=X the X would be collected,
and the unit will be distributed across those Xs. If that list
change because of autoscaling event, the list will always be regenerated
before scheduling unit.

If there is no az tag, nothing happen the logic stays the same as before.
