### PR TITLE
DOS-2734: [ROUTER] Allows for nginx loadbalancing algorithm to be def…

### DIFF
--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -191,6 +191,9 @@ http {
         {{ if exists "/deis/router/affinityArg" }}
         hash $arg_{{ getv "/deis/router/affinityArg" }} consistent;
         {{ end }}
+        {{ if exists "/deis/router/loadbalancer/algorithm" }}
+        {{ getv "/deis/router/loadbalancer/algorithm" }};
+        {{ end }}
         {{ range gets $upstreams }}server {{ .Value }};
         {{ end }}
     }


### PR DESCRIPTION
…ined at /deis/router/loadbalancer/algorithm to change the Nginx loadbalancing algorithm for applications. Leaving /deis/router/loadbalancer/algorithm unset will use the default of round robin, but setting /deis/router/loadbalancer/algorithm="least_conn", for example, will use the least connections algorithm. Available options are "least_conn", "ip_hash". "hash $request_uri consistent", "least_time header" or "least_time last_byte" as described here https://www.nginx.com/resources/admin-guide/load-balancer/
