### PR TITLE
[CONTROLLER] Increase restart timeout of fleet units (temporarily?). …

### DIFF
--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -422,7 +422,7 @@ CONTAINER_TEMPLATE = [
     {"section": "Service", "name": "ExecStop", "value": '''/bin/sh -c "docker stop {name}; rm /tmp/env_files/{name}"'''},  # noqa
     {"section": "Service", "name": "TimeoutStartSec", "value": "20m"},
     {"section": "Service", "name": "TimeoutStopSec", "value": "10"},
-    {"section": "Service", "name": "RestartSec", "value": "5"},
+    {"section": "Service", "name": "RestartSec", "value": "90"},
     {"section": "Service", "name": "Restart", "value": "on-failure"},
 ]
 


### PR DESCRIPTION
…Currently, when a unit fails for a missing image or otherwise we continue to attempt to pull that image every 5 seconds forever. Increasing the timeout lowers the load we are generating for Quay but is not a permanent solution. A permanent solution will be implemented when CoreOS systemd version is increased to 229 which allows StartLimitIntervalSec and StartLimitBurst to be declared.
