### PR TITLE
[ROUTER] Remove vhost status directives. We are receiving constant wa…

### DIFF
--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -13,8 +13,6 @@ events {
 
 http {
     # basic settings
-    vhost_traffic_status_zone shared:vhost_traffic_status:{{ or (getv "/deis/router/trafficStatusZoneSize") "1m" }};
-
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
@@ -388,10 +386,6 @@ http {
             default_type 'text/plain';
             return 200;
             {{ end }}
-        }
-        location /router-nginx-status {
-            vhost_traffic_status_display;
-            vhost_traffic_status_display_format html;
         }
         location / {
             return 404;


### PR DESCRIPTION
…rnings/errors about the size of this directive even though we have set it to 1GB or more. We do not use this vhost status page so it seems useless
