### PR TITLE
[ROUTER] Set Proxy headers to blank string for (CVE-2016-5385/5386/53…

### DIFF
--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -64,6 +64,7 @@ http {
                              '"upstream_addr": "$upstream_addr", '
                              '"upstream_response_time": "$upstream_response_time", '
                              '"http_host": "$http_host", '
+                             '"http_proxy": "$http_proxy", '
                              '"http_referer": "$http_referer", '
                              '"http_user_agent": "$http_user_agent" } }';
 
@@ -132,6 +133,7 @@ http {
             proxy_buffering             off;
             proxy_set_header            Host $host;
             proxy_set_header            X-Forwarded-For $remote_addr;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       {{ or (getv "/deis/router/controller/timeout/connect") "10s" }};
             proxy_send_timeout          {{ or (getv "/deis/router/controller/timeout/send") "20m" }};
@@ -181,6 +183,7 @@ http {
             proxy_buffering             off;
             proxy_set_header            Host $host;
             proxy_set_header            X-Forwarded-For $remote_addr;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       10s;
             proxy_send_timeout          {{ $defaultTimeout }}s;
@@ -264,6 +267,7 @@ http {
             proxy_set_header            X-Forwarded-Proto $access_scheme;
             proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       30s;
             proxy_send_timeout          {{ $defaultTimeout }}s;
@@ -339,6 +343,7 @@ http {
             proxy_set_header            X-Forwarded-Proto $access_scheme;
             proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       30s;
             proxy_send_timeout          {{ $defaultTimeout }}s;
@@ -459,6 +464,7 @@ http {
             proxy_set_header            X-Forwarded-Proto $access_scheme;
             proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       30s;
             proxy_send_timeout          {{ $defaultTimeout }}s;
@@ -517,6 +523,7 @@ http {
             proxy_set_header            X-Forwarded-Proto $access_scheme;
             proxy_set_header            X-Forwarded-For   $remote_addr;
             proxy_set_header            X-Forwarded-Ssl   $access_ssl;
+            proxy_set_header            Proxy "";
             proxy_redirect              off;
             proxy_connect_timeout       30s;
             proxy_send_timeout          {{ $defaultTimeout }}s;


### PR DESCRIPTION
…87/5388/1000109/1000110) as per https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/. The CGI recommendations are handled at the PHP Nginx level
