### PR TITLE
Add service-name label to containers

### DIFF
--- a/controller/api/models.py
+++ b/controller/api/models.py
@@ -660,7 +660,8 @@ class Container(UuidAuditedModel):
         kwargs = {'memory': self.release.config.memory,
                   'cpu': self.release.config.cpu,
                   'tags': self.release.config.tags,
-                  'values': self.release.config.values}
+                  'values': self.release.config.values,
+                  'aname': self.app.id}
         try:
             self._scheduler.create(
                 name=self.job_id,
@@ -715,8 +716,12 @@ class Container(UuidAuditedModel):
             command = "'{}'".format(command)
         else:
             command = "-c '{}'".format(command)
-        kwargs = {'memory': self.release.config.memory, 'cpu': self.release.config.cpu,
-                  'tags': self.release.config.tags, 'values': self.release.config.values, 'entrypoint': entrypoint}
+        kwargs = {'memory': self.release.config.memory,
+                  'cpu': self.release.config.cpu,
+                  'tags': self.release.config.tags,
+                  'values': self.release.config.values,
+                  'entrypoint': entrypoint,
+                  'aname': self.app.id}
         try:
             rc, output = self._scheduler.run(self.job_id, image, command, **kwargs)
             return rc, output

--- a/controller/scheduler/fleet.py
+++ b/controller/scheduler/fleet.py
@@ -171,6 +171,13 @@ class FleetHTTPClient(AbstractSchedulerClient):
         else:
             l.update({'cpu': ''})
 
+        # prepare the service name label
+        aname = kwargs.get('aname', None)
+        if aname:
+            l.update({'aname': '-l service-name={}'.format(aname)})
+        else:
+            l.update({'aname': ''})
+
         # set unit hostname
         l.update({'hostname': self._get_hostname(name)})
         # should a special entrypoint be used
@@ -418,7 +425,7 @@ CONTAINER_TEMPLATE = [
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "IMAGE={image}; docker pull $IMAGE"'''},  # noqa
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "docker inspect {name} >/dev/null 2>&1 && docker rm -f {name} || true"'''},  # noqa
     {"section": "Service", "name": "ExecStartPre", "value": '''/bin/sh -c "mkdir -p /tmp/env_files && echo '' > /tmp/env_files/{name}"'''},  # noqa
-    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE={image}; docker run --name {name} --rm --env-file /tmp/env_files/{name} {memory} {cpu} {hostname} -P $IMAGE {command}"'''},  # noqa
+    {"section": "Service", "name": "ExecStart", "value": '''/bin/sh -c "IMAGE={image}; docker run --name {name} --rm --env-file /tmp/env_files/{name} {memory} {cpu} {hostname} {aname} -P $IMAGE {command}"'''},  # noqa
     {"section": "Service", "name": "ExecStop", "value": '''/bin/sh -c "docker stop {name}; rm /tmp/env_files/{name}"'''},  # noqa
     {"section": "Service", "name": "TimeoutStartSec", "value": "20m"},
     {"section": "Service", "name": "TimeoutStopSec", "value": "10"},


### PR DESCRIPTION
This adds a service-name label to the deployed containers for easier filtering in sysdig.

Attached example is visualizing the edit container cpu usage, splitting on image so you can see cpu usage surrounding a deployment.

![screen shot 2016-09-21 at 4 24 39 pm](https://cloud.githubusercontent.com/assets/156065/18727778/51c64cd4-8018-11e6-81f7-6ff3b610864d.png)
