### PR TITLE
CCB-1064: Increase proxy buffer sizes to support larger response headers

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/hearst/deis-router:v.1.12.2-21-af7012a
 
-COPY rootfs /
+COPY rootfs/etc/confd/templates/nginx.conf /etc/confd/templates/nginx.conf
 
 CMD ["boot"]
 EXPOSE 80 2222 9090

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,28 +1,6 @@
-FROM alpine:3.2
-
-# install common packages
-RUN apk add --update-cache \
-	bash \
-	curl \
-	geoip \
-	libssl1.0 \
-	openssl \
-	pcre \
-	sudo \
-	&& rm -rf /var/cache/apk/*
-
-# install confd
-RUN curl -sSL -o /usr/local/bin/confd https://s3-us-west-2.amazonaws.com/opdemand/confd-git-73f7489 \
-  && chmod +x /usr/local/bin/confd
-
-# add nginx user
-RUN addgroup -S nginx && \
-  adduser -S -G nginx -H -h /opt/nginx -s /sbin/nologin -D nginx
+FROM quay.io/hearst/deis-router:v.1.12.2-21-af7012a
 
 COPY rootfs /
-
-# compile nginx from source
-RUN build
 
 CMD ["boot"]
 EXPOSE 80 2222 9090

--- a/router/rootfs/etc/confd/templates/nginx.conf
+++ b/router/rootfs/etc/confd/templates/nginx.conf
@@ -278,6 +278,14 @@ http {
 
             proxy_next_upstream         error timeout http_502 http_503 http_504;
 
+            # By default nginx limits the response headers to 4k, which is typically sufficient, however we use a very long
+            # Surrogate-Key header.  The Surrogate-Key header is limited to 16k by Fastly, so increase the maximum header
+            # size to 20k (4k + 16k) and keep all buffer configuration values at the same ratio as their default values.
+            # https://docs.fastly.com/guides/purging/getting-started-with-surrogate-keys#limitations
+            proxy_buffers 40 4k;         # Default = 8 4k
+            proxy_buffer_size 20k;       # Default = 4k
+            proxy_busy_buffers_size 40k; # Default = 8k
+
             {{ if or (eq $enforceHTTPS "true") (eq $appForceSSL "true") }}
             if ($access_scheme != "https") {
               return 301 https://$host$request_uri;
@@ -353,6 +361,14 @@ http {
             proxy_set_header            Connection        $connection_upgrade;
 
             proxy_next_upstream         error timeout http_502 http_503 http_504;
+
+            # By default nginx limits the response headers to 4k, which is typically sufficient, however we use a very long
+            # Surrogate-Key header.  The Surrogate-Key header is limited to 16k by Fastly, so increase the maximum header
+            # size to 20k (4k + 16k) and keep all buffer configuration values at the same ratio as their default values.
+            # https://docs.fastly.com/guides/purging/getting-started-with-surrogate-keys#limitations
+            proxy_buffers 40 4k;         # Default = 8 4k
+            proxy_buffer_size 20k;       # Default = 4k
+            proxy_busy_buffers_size 40k; # Default = 8k
 
             {{ if or (eq $enforceHTTPS "true") (eq $appForceSSL "true") }}
             if ($access_scheme != "https") {


### PR DESCRIPTION
https://thetower.atlassian.net/browse/CCB-1064

The fre-hdm application needs to send larger headers to Fastly in order to fit all surrogate keys in the response.  nginx tightly limits the the length of the header field it can accept, even when proxy_buffering is explicitly disabled.  Here we select new values that allow the response headers to contain up to 16k of surrogate keys, in addition to 4k (the current default) of space for other headers.  Additionally, we maintain the ratios between the other buffer related configuration directives that nginx requires are set.